### PR TITLE
Add playback status support

### DIFF
--- a/include/np.h
+++ b/include/np.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stdio.h>
 #include <time.h>
 
 void np_init();
@@ -11,6 +12,16 @@ enum np_playback_type {
 	np_playback_type_music,
 	np_playback_type_video,
 	np_playback_type_image,
+};
+
+enum np_playback_status_type {
+	np_playbackStatus_type_unknown,
+	np_playbackStatus_type_closed,
+	np_playbackStatus_type_opened,
+	np_playbackStatus_type_changing,
+	np_playbackStatus_type_stopped,
+	np_playbackStatus_type_playing,
+	np_playbackStatus_type_paused,
 };
 
 struct np_info {
@@ -33,7 +44,6 @@ struct np_info {
 	char *created; // linux only
 	char *first_played; // linux only
 	char *last_played; // linux only
-
 	char *album;
 	int album_track_count; // windows only
 	char *art_url; // linux only
@@ -46,6 +56,12 @@ struct np_info {
 	int track_number;
 	char *url; // linux only
 
+	int position; // windows only
+	int start_time; // windows only
+	int end_time; // windows only
+	int last_updated; // windows only
+
+	enum np_playback_status_type playback_status; // windows only
 	enum np_playback_type playback_type; // windows only
 };
 

--- a/np/main.c
+++ b/np/main.c
@@ -61,6 +61,15 @@ int main() {
 		if (info->track_number) {
 			printf("Track Number: %d\n", info->track_number);
 		}
+		if (info->start_time) {
+			printf("Start Time: %d\n", info->start_time);
+		}
+		if (info->end_time) {
+			printf("End Time: %d\n", info->end_time);
+		}
+		if (info->position) {
+			printf("Position: %d\n", info->position);
+		}
 		if (info->url) {
 			printf("URL: %s\n", info->url);
 		}
@@ -73,6 +82,28 @@ int main() {
 			break;
 		case np_playback_type_video:
 			printf("Type: Video\n");
+			break;
+		default:
+			break;
+		}
+		switch (info->playback_status) {
+		case np_playbackStatus_type_closed:
+			printf("Status: Closed\n");
+			break;
+		case np_playbackStatus_type_opened:
+			printf("Status: Opened\n");
+			break;
+		case np_playbackStatus_type_changing:
+			printf("Status: Changing\n");
+			break;
+		case np_playbackStatus_type_stopped:
+			printf("Status: Stopped\n");
+			break;
+		case np_playbackStatus_type_playing:
+			printf("Status: Playing\n");
+			break;
+		case np_playbackStatus_type_paused:
+			printf("Status: Paused\n");
 			break;
 		default:
 			break;


### PR DESCRIPTION
This pull request implements new fields in the track playback structure

- `position`: playback position in the current track
- `start_time`: track start position (usually always 0?)
- `end_time`: track end position
- `last_updated`: last status update time
- `playback_status`: playback status of the track (_closed, opened, changing, stopped, playing, paused_)